### PR TITLE
Reproducer for gfortran bug 98141

### DIFF
--- a/gfortran-bugs/CMakeLists.txt
+++ b/gfortran-bugs/CMakeLists.txt
@@ -5,6 +5,8 @@ include(testing)
 
 project(gfortran-bug Fortran)
 
+add_compiler_test(SOURCES gfortran-20201204a.f90 RUN_ONLY LABELS PR98141)
+add_compiler_test(SOURCES gfortran-20201204b.f90 RUN_ONLY LABELS PR98141)
 add_compiler_test(SOURCES gfortran-20200501.f90 COMPILE_ONLY LABELS PR94909)
 add_compiler_test(SOURCES gfortran-20200402-file1.f90 gfortran-20200402-file2.f90
     LINK_ONLY LABELS PR94463)

--- a/gfortran-bugs/gfortran-20201204a.f90
+++ b/gfortran-bugs/gfortran-20201204a.f90
@@ -1,0 +1,7 @@
+program main
+  class(*), allocatable :: a, b, c
+  character(len=0) :: s
+  allocate(a, source=s)  !! No problem
+  allocate(character(len=0)::b)
+  allocate(c, source=b)  !! Segfault
+end program

--- a/gfortran-bugs/gfortran-20201204b.f90
+++ b/gfortran-bugs/gfortran-20201204b.f90
@@ -1,0 +1,5 @@
+program main
+  class(*), allocatable :: a, b
+  allocate(a, source='')  !! No problem
+  allocate(b, source=a)   !! Segfault
+end program


### PR DESCRIPTION
This PR adds a minimal reproducer for [gfortran bug 98141](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98141).